### PR TITLE
Removed unnecessary print lines from sqlite connection

### DIFF
--- a/src/db/sqlite/mod.rs
+++ b/src/db/sqlite/mod.rs
@@ -99,7 +99,6 @@ impl DBConnection for Mutex<SqliteConnection> {
     async fn init(&self) -> Result<()> {
         let mut db = self.lock().await;
         query(CREATE_TABLE).execute(&mut *db).await?;
-        println!("table created");
         Ok(())
     }
     async fn create_user(&self, email: &str, hash: &str, is_admin: bool) -> Result<()> {
@@ -207,7 +206,6 @@ impl DBConnection for SqlitePool {
     }
     async fn get_user_by_email(&self, email: &str) -> Result<User> {
         let user = query_as(SELECT_BY_EMAIL).bind(email).fetch_one(self).await;
-        println!("user: {:?}", user);
         Ok(user?)
     }
 }


### PR DESCRIPTION
Hi!

Thank you for this wonderful crate!

While using it I noticed that in the DBConnection for the sqlx-sqlite connection there where print line macros.
This is not the case for any other databases, so I thought I send you a quick and small pr.

Have a nice day!